### PR TITLE
internal/ccall: silence conversion warnings in Darwin builds

### DIFF
--- a/internal/ccall/ccflags_darwin.go
+++ b/internal/ccall/ccflags_darwin.go
@@ -1,0 +1,4 @@
+package ccall
+
+//#cgo CFLAGS: -Wno-single-bit-bitfield-constant-conversion
+import "C"


### PR DESCRIPTION
Updates tailscale/corp#19068

Signed-off-by: M. J. Fromberger <fromberger@tailscale.com>
